### PR TITLE
build: Install OpenSSL with chocolatey only for x64 (#7719)

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -72,7 +72,7 @@ jobs:
         config:
           - name: "Windows 32bit"
             arch: x86
-            openssl_dir: C:\Program Files (x86)\OpenSSL-Win32
+            openssl_dir: C:\vcpkg\packages\openssl_x86-windows-static
             chocolatey_opt: --x86
             cmake_additional_opt: ""
             vcpkg_triplet: x86-windows-static
@@ -111,7 +111,7 @@ jobs:
         shell: pwsh
 
       - name: Get dependencies w/ chocolatey
-        if: ${{ matrix.config.arch != 'amd64_arm64' }}
+        if: ${{ matrix.config.arch == 'x64' }}
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install ${{ matrix.config.chocolatey_opt }} openssl -y
@@ -122,7 +122,7 @@ jobs:
           arch: ${{ matrix.config.arch }}
 
       - name: Build openssl with vcpkg
-        if: ${{ matrix.config.arch == 'amd64_arm64' }}
+        if: ${{ matrix.config.arch != 'x64' }}
         run: |
           C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd


### PR DESCRIPTION
* build: Install OpenSSL with chocolatey only for x64

This is because Chocolatey only supports x64 installation after OpenSSL 3.1.1 package.

ref: https://community.chocolatey.org/packages/openssl/3.1.1#files



* build: Use the correct directory to refer the installed place of OpenSSL



---------

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
